### PR TITLE
Update to latest upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: rust
+cache:
+  - cargo
+rust:
+  - stable
+  - beta
+  - nightly
+os:
+  - linux
+  - osx
+  - windows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,15 +110,12 @@ dependencies = [
 
 [[package]]
 name = "crev-recursive-digest"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7902cde91068de5e0c34a5887db4b8e1918ccb7abd0dfae76f155a8c8d3042e1"
+checksum = "1233fe7d47fb9e28a9ec9a31ff37b7d236addd80c8c0a94950daa7d3d4f0d875"
 dependencies = [
- "blake2",
  "digest",
- "failure",
- "failure_derive",
- "generic-array",
+ "thiserror",
  "walkdir",
 ]
 
@@ -391,6 +388,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee14bf8e6767ab4c687c9e8bc003879e042a96fd67a3ba5934eadb6536bef4db"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ failure = "0.1"
 common_failures = "0.1"
 structopt = "0.3"
 env_logger = { version = "0.6.2", default-features = false, features = []}
-log = "*"
-crev-recursive-digest = { version = "0.2.1" }
+log = "0.4"
+crev-recursive-digest = { version = "0.4.0" }
 glob = "0.3"
 blake2 = "0.8"
 base64 = "0.11"

--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ and then hashing all of these together, to give you deterministic checksum,
 before you even attempt to call `docker build`. You can use it as a
 deterministic content-based ID to avoid rebuilding containers that
 were already built (eg. by taging them with that checksum).
+
+# Warnings and missing features
+
+* don't use it on untrusted `Dockerfiles`
+* the exact checksum is not stable yet and can change between versions
+* `["src1", "src", "dst"]` syntax of `ADD` and `COPY` is not supported (PRs welcome)
+* file modes and ownership is ignored
+* it was put together in 2 hours, so if you plan to use it in production, maybe... review the code or something and tell me it's OK
+
+Having said that, seems to work great.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ were already built (eg. by taging them with that checksum).
 * don't use it on untrusted `Dockerfiles`
 * the exact checksum is not stable yet and can change between versions
 * `["src1", "src", "dst"]` syntax of `ADD` and `COPY` is not supported (PRs welcome)
-* file modes and ownership is ignored
-* it was put together in 2 hours, so if you plan to use it in production, maybe... review the code or something and tell me it's OK
+* file ownership is ignored
+* it was put together in 2 hours, so if you plan to use it in production, maybe... review the code or something and tell me what you think
 
 Having said that, seems to work great.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ even when the rest of the monorepo did.
 `docker-source-checksum` will calculate a hash of:
 
 * `Dockerfile` content
-* all source files referenced by that `Dockerfile` (by parsing it)
+* all source files referenced by that `Dockerfile` (figured out by parsing it)
 * any additiona arguments that might affect the build
 
 and then hashing all of these together, to give you deterministic checksum,


### PR DESCRIPTION
One papercut was that permissions on the source code files were
ignored, while from time to time someone might want to rebuild a container
just because it required `chmod +x` somewhere.